### PR TITLE
Add support for Python 2.7 and 3+

### DIFF
--- a/Pashua.py
+++ b/Pashua.py
@@ -54,16 +54,15 @@ def run(config_data, pashua_path=None):
 
 
     # Send string to pashua standard input, receive result.
-    s=subprocess.Popen([app_path,  "-"], 
+    s=subprocess.Popen([app_path,  "-"],
                         stdin=subprocess.PIPE,
-                        stdout=subprocess.PIPE, 
+                        stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE)
-    (result, outerror)=s.communicate(input=config_data)
-
+    result, _ = s.communicate(input=config_data)
 
     # Parse result
     d = {}
-    for line in result.split('\n'):
+    for line in result.decode('utf8').splitlines():
         if '=' in line: # avoid empty lines.
             k, _, v = line.partition('=')
             d[k] = v.rstrip()

--- a/Pashua.py
+++ b/Pashua.py
@@ -42,7 +42,7 @@ def locate_pashua(pashua_path=None):
         if os.path.exists(bundle_path):
             return bundle_path
 
-    raise IOError, "Unable to locate the Pashua application."
+    raise IOError("Unable to locate the Pashua application.")
 
 
 # Calls the pashua executable, parses its result string and generates

--- a/example.py
+++ b/example.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import Pashua
 import os.path
 
-conf = """
+conf = u"""
 # Set window title
 *.title = Welcome to Pashua
 
@@ -92,14 +92,14 @@ icon = app_bundle + '/Resources/AppIcon@2.png'
 
 if os.path.exists(icon):
     # Display Pashua's icon
-    conf += """img.type = image
-               img.x = 435
-               img.y = 248
-               img.maxwidth = 128
-               img.tooltip = This is an element of type 'image'
-               img.path = %s""" % icon
+    conf += u"""img.type = image
+                img.x = 435
+                img.y = 248
+                img.maxwidth = 128
+                img.tooltip = This is an element of type 'image'
+                img.path = %s""" % icon
 
-result = Pashua.run(conf)
+result = Pashua.run(conf.encode('utf8'))
 
 print("Pashua returned the following dictionary keys and values:")
 


### PR DESCRIPTION
Just a few small tweaks to the demo code that add support for newer versions of Python.

Tested with 2.6, 2.7 and 3.5 – all now work with the same code.